### PR TITLE
[改善] crabplay から学んだパターンを適用

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,32 @@
+name: Auto Format
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Run cargo fmt
+        run: cargo fmt
+
+      - name: Commit formatting fixes if any
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "style: apply cargo fmt"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            suffix: x86_64-linux
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            suffix: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            suffix: x86_64-windows
+            ext: .exe
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+
+      - name: Verify Cargo.toml version matches tag
+        shell: bash
+        run: |
+          CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$CARGO_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch: Cargo.toml=${CARGO_VERSION}, tag=${TAG_VERSION}"
+            exit 1
+          fi
+          echo "Version: ${CARGO_VERSION}"
+
+      - name: Build release binary
+        run: cargo build --release --locked --target ${{ matrix.target }}
+
+      - name: Package binary (Unix)
+        if: matrix.os != 'windows-latest'
+        run: |
+          BIN_NAME=$(grep '^name' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          VERSION="${GITHUB_REF_NAME}"
+          ARCHIVE="${BIN_NAME}-${VERSION}-${{ matrix.suffix }}.tar.gz"
+          tar -czf "$ARCHIVE" -C target/${{ matrix.target }}/release "$BIN_NAME"
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Package binary (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          BIN_NAME=$(grep '^name' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          VERSION="${GITHUB_REF_NAME}"
+          ARCHIVE="${BIN_NAME}-${VERSION}-${{ matrix.suffix }}.zip"
+          7z a "$ARCHIVE" "target/${{ matrix.target }}/release/${BIN_NAME}.exe"
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ env.ARCHIVE }}
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Rust CLI / ライブラリプロジェクトのテンプレート。モジュー
 - **バリデーション分離**: `Args::validate()` で clap では表現できない制約を検証
 - **LazyLock 正規表現**: `std::sync::LazyLock` による一度きりの正規表現コンパイル
 - **統合テスト**: `assert_cmd` + `predicates` による CLI 動作の自動検証
-- **CI 対応**: GitHub Actions で 3OS (macOS, Ubuntu, Windows) × fmt / clippy / test
+- **CI 対応**: GitHub Actions で 3OS (macOS, Ubuntu, Windows) × fmt / clippy / test。PR 時の自動フォーマットコミットも含む
+- **リリース自動化**: `v*` タグ push でマルチプラットフォームバイナリを GitHub Releases に自動公開
 - **リリース最適化**: LTO, strip, codegen-units=1 による小サイズバイナリ
 
 ## プロジェクト構成
@@ -27,7 +28,9 @@ src/
 tests/
 └── cli_integration.rs   assert_cmd 統合テスト (5件)
 .github/workflows/
-└── ci.yml               GitHub Actions CI パイプライン
+├── ci.yml               GitHub Actions CI パイプライン (3OS × fmt/clippy/test)
+├── fmt.yml              PR 時の自動フォーマット + コミット
+└── release.yml          タグ push による自動リリース (Linux/macOS/Windows)
 ```
 
 ## インストール
@@ -92,11 +95,13 @@ cargo build --release
 | パターン | 出典プロジェクト |
 |---|---|
 | リリースプロファイル最適化 | rpg (パスワード生成CLI) |
-| `assert_cmd` 統合テスト | rpg |
+| `assert_cmd` 統合テスト (`env!` マクロ) | crabplay (音楽プレーヤーCLI) |
 | `OutputFormatter` トレイト | gymeat (食事プランCLI) |
 | `validate()` バリデーション分離 | gymeat |
 | マルチOS CI パイプライン | gymeat |
 | `LazyLock<Regex>` パターン | youtube-audio-downloader |
+| PR 自動フォーマット (`fmt.yml`) | crabplay |
+| タグ push 自動リリース (`release.yml`) | crabplay |
 
 ## 拡張ガイド
 

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,11 +1,8 @@
-#[allow(deprecated)]
-use assert_cmd::cargo::cargo_bin;
+use assert_cmd::Command;
 use predicates::prelude::*;
 
-fn cmd() -> assert_cmd::Command {
-    #[allow(deprecated)]
-    let bin = cargo_bin("rust-cli-template");
-    assert_cmd::Command::from(std::process::Command::new(bin))
+fn cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_rust-cli-template"))
 }
 
 #[test]
@@ -41,7 +38,10 @@ fn test_version_flag() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("rust-cli-template 0.1.0"));
+        .stdout(predicate::str::contains(format!(
+            "rust-cli-template {}",
+            env!("CARGO_PKG_VERSION")
+        )));
 }
 
 #[test]


### PR DESCRIPTION
## 概要

実プロジェクト crabplay の実装パターンを参考に、テンプレートの品質を改善する。

## 変更内容

- **統合テストの改善** (`tests/cli_integration.rs`)
  - 非推奨の `cargo_bin()` + `#[allow(deprecated)]` を `env!("CARGO_BIN_EXE_...")` に置き換え
  - バージョンテストのハードコード (`0.1.0`) を `env!("CARGO_PKG_VERSION")` に変更

- **PR 時の自動フォーマット追加** (`.github/workflows/fmt.yml`)
  - PR 時に `cargo fmt` を自動実行し、差分があればコミットを自動追加

- **リリース自動化追加** (`.github/workflows/release.yml`)
  - `v*` タグ push でトリガー
  - `Cargo.toml` バージョンとタグの一致を検証
  - Linux / macOS / Windows 向けバイナリをビルドし GitHub Releases に自動公開

- **ドキュメント更新** (`README.md`)
  - 上記変更を特徴・プロジェクト構成・設計パターン出典表に反映

## 動作確認

- [x] `cargo test` 全テストパス（ユニット 9件、統合 5件）
- [x] `cargo clippy -- -D warnings` 警告なし

## 関連 Issue

なし

## スクリーンショット（該当する場合）

なし