### PR TITLE
feat: サブコマンド構造の追加 (parse / check)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 use crate::error::AppError;
 
@@ -6,6 +6,9 @@ use crate::error::AppError;
 #[derive(Parser, Debug)]
 #[command(name = "rust-cli-template", version, about)]
 pub struct Args {
+    #[command(subcommand)]
+    pub command: Option<SubCommand>,
+
     /// Input file path to process
     #[arg(short, long)]
     pub input: Option<String>,
@@ -14,23 +17,34 @@ pub struct Args {
     #[arg(short, long, default_value_t = false)]
     pub verbose: bool,
 
-    /// Output format (json / text)
+    /// Output format (json / text)  [parse サブコマンドで使用]
     #[arg(short, long, default_value = "text")]
     pub format: String,
 }
 
+/// サブコマンド一覧。
+/// 省略時は `parse` と同等の動作をする（後方互換性の維持）。
+#[derive(Subcommand, Debug)]
+pub enum SubCommand {
+    /// 入力をパースし AST を表示する（デフォルト動作）
+    Parse,
+    /// 入力を検証するのみ。出力なし、終了コードで結果を返す
+    Check,
+}
+
 impl Args {
     /// clap の宣言的バリデーションでは表現できない制約を検証する。
-    ///
-    /// より複雑なバリデーションが必要な場合は、別途 `Config` 構造体を
-    /// 作成し `validate()` メソッドを持たせる（gymeat の PlanConfig を参照）。
     pub fn validate(&self) -> Result<(), AppError> {
-        match self.format.as_str() {
-            "text" | "json" => {}
-            other => {
-                return Err(AppError::Other(format!(
-                    "unsupported format: '{other}' (expected 'text' or 'json')"
-                )));
+        // `check` サブコマンドでは format は使用しないためスキップ
+        let is_check = matches!(self.command, Some(SubCommand::Check));
+        if !is_check {
+            match self.format.as_str() {
+                "text" | "json" => {}
+                other => {
+                    return Err(AppError::Other(format!(
+                        "unsupported format: '{other}' (expected 'text' or 'json')"
+                    )));
+                }
             }
         }
 
@@ -51,6 +65,7 @@ mod tests {
     #[test]
     fn validate_accepts_known_formats() {
         let args = Args {
+            command: None,
             input: None,
             verbose: false,
             format: "json".to_string(),
@@ -61,10 +76,22 @@ mod tests {
     #[test]
     fn validate_rejects_unknown_format() {
         let args = Args {
+            command: None,
             input: None,
             verbose: false,
             format: "xml".to_string(),
         };
         assert!(args.validate().is_err());
+    }
+
+    #[test]
+    fn validate_skips_format_check_for_check_subcommand() {
+        let args = Args {
+            command: Some(SubCommand::Check),
+            input: None,
+            verbose: false,
+            format: "xml".to_string(), // check では無視される
+        };
+        assert!(args.validate().is_ok());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,29 +2,26 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use colored::Colorize;
 
-use rust_cli_template::cli::Args;
+use rust_cli_template::cli::{Args, SubCommand};
 use rust_cli_template::output::{JsonFormatter, OutputFormatter, TextFormatter};
 use rust_cli_template::parse_input;
 
-fn run(args: &Args) -> Result<()> {
-    args.validate().context("argument validation failed")?;
-
-    let input = match &args.input {
+fn load_input(input: &Option<String>) -> Result<String> {
+    match input {
         Some(path) => std::fs::read_to_string(path)
-            .with_context(|| format!("failed to read file: {}", path))?,
-        None => {
-            // デモ用: 引数なしの場合はサンプル入力を使用
-            "42".to_string()
-        }
-    };
+            .with_context(|| format!("failed to read file: {}", path)),
+        None => Ok("42".to_string()),
+    }
+}
 
-    if args.verbose {
+fn run_parse(input: &str, format: &str, verbose: bool) -> Result<()> {
+    if verbose {
         eprintln!("{} parsing input...", "[info]".blue());
     }
 
-    let node = parse_input(&input)?;
+    let node = parse_input(input)?;
 
-    let formatter: Box<dyn OutputFormatter> = match args.format.as_str() {
+    let formatter: Box<dyn OutputFormatter> = match format {
         "json" => Box::new(JsonFormatter),
         _ => Box::new(TextFormatter),
     };
@@ -37,6 +34,33 @@ fn run(args: &Args) -> Result<()> {
         "text" => println!("{} {output}", "[result]".green()),
         _ => println!("{output}"),
     };
+
+    Ok(())
+}
+
+fn run_check(input: &str, verbose: bool) -> Result<()> {
+    if verbose {
+        eprintln!("{} checking input...", "[info]".blue());
+    }
+
+    parse_input(input)?;
+
+    if verbose {
+        eprintln!("{} input is valid", "[info]".blue());
+    }
+
+    Ok(())
+}
+
+fn run(args: &Args) -> Result<()> {
+    args.validate().context("argument validation failed")?;
+
+    let input = load_input(&args.input)?;
+
+    match args.command.as_ref().unwrap_or(&SubCommand::Parse) {
+        SubCommand::Parse => run_parse(&input, &args.format, args.verbose)?,
+        SubCommand::Check => run_check(&input, args.verbose)?,
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,9 @@ use rust_cli_template::parse_input;
 
 fn load_input(input: &Option<String>) -> Result<String> {
     match input {
-        Some(path) => std::fs::read_to_string(path)
-            .with_context(|| format!("failed to read file: {}", path)),
+        Some(path) => {
+            std::fs::read_to_string(path).with_context(|| format!("failed to read file: {}", path))
+        }
         None => Ok("42".to_string()),
     }
 }

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -5,6 +5,8 @@ fn cmd() -> Command {
     Command::new(env!("CARGO_BIN_EXE_rust-cli-template"))
 }
 
+// --- 後方互換: サブコマンドなし = parse 動作 ---
+
 #[test]
 fn test_default_run_succeeds() {
     cmd()
@@ -51,4 +53,53 @@ fn test_invalid_input_file() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("error"));
+}
+
+// --- parse サブコマンド ---
+
+#[test]
+fn test_parse_subcommand_default_output() {
+    cmd()
+        .arg("parse")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("IntLiteral"));
+}
+
+#[test]
+fn test_parse_subcommand_json_format() {
+    cmd()
+        .args(&["--format", "json", "parse"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\"kind\""));
+}
+
+// --- check サブコマンド ---
+
+#[test]
+fn test_check_subcommand_valid_input() {
+    cmd()
+        .arg("check")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_empty());
+}
+
+#[test]
+fn test_check_subcommand_invalid_file() {
+    cmd()
+        .args(&["--input", "nonexistent_file.txt", "check"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn test_check_subcommand_has_help() {
+    cmd()
+        .args(&["check", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("check"));
 }


### PR DESCRIPTION
## 概要

- `SubCommand` enum（`parse` / `check`）を `cli.rs` に追加
- サブコマンドなし時は `parse` と同等の動作を維持（後方互換）
- `main.rs` を `load_input` / `run_parse` / `run_check` に分割してディスパッチ
- `check` サブコマンドでは出力がないため format バリデーションをスキップ

## テスト計画

- [ ] `cargo test` — 全20件通過（ユニット10件 + 統合10件）
- [ ] `cargo run -- parse` — AST を出力（従来と同じ）
- [ ] `cargo run -- check` — 終了コード0、標準出力なし
- [ ] `cargo run -- --format json parse` — JSON を出力
- [ ] `cargo run`（サブコマンドなし）— 後方互換、`parse` と同じ出力

Closes #2